### PR TITLE
Make default output more user friendly for humans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ Usage
 ```bash
 Usage: gostatus [flags] [packages]
        [newline separated packages] | gostatus -stdin [flags]
+  -c  Compact output with inline notation.
   -debug
-    	Cause the repository data to be printed in verbose debug format.
-  -f	Force not to verify that each package has been checked out from the source control repository implied by its import path. This can be useful if the source is a local fork of the original.
+      Cause the repository data to be printed in verbose debug format.
+  -f  Force not to verify that each package has been checked out from the source control repository implied by its import path. This can be useful if the source is a local fork of the original.
   -stdin
-    	Read the list of newline separated Go packages from stdin.
-  -v	Verbose mode. Show all Go packages, not just ones with notable status.
+      Read the list of newline separated Go packages from stdin.
+  -v  Verbose mode. Show all Go packages, not just ones with notable status.
 
 Examples:
   # Show status of all packages.
@@ -33,11 +34,11 @@ Examples:
   go list -f '{{join .Deps "\n"}}' . | gostatus -stdin -v
 
 Legend:
-  ???? - Not under (recognized) version control
+  ? - Not under (recognized) version control
   b - Non-master branch checked out
   * - Uncommited changes in working dir
   + - Update available
-  - - Local revision is ahead of remote (need to push?)
+  - - Local revision is ahead of remote
   ! - No remote
   # - Remote path doesn't match import path
   $ - Stash exists

--- a/main.go
+++ b/main.go
@@ -15,10 +15,11 @@ import (
 const parallelism = 8
 
 var (
-	debugFlag = flag.Bool("debug", false, "Cause the repository data to be printed in verbose debug format.")
-	fFlag     = flag.Bool("f", false, "Force not to verify that each package has been checked out from the source control repository implied by its import path. This can be useful if the source is a local fork of the original.")
-	stdinFlag = flag.Bool("stdin", false, "Read the list of newline separated Go packages from stdin.")
-	vFlag     = flag.Bool("v", false, "Verbose mode. Show all Go packages, not just ones with notable status.")
+	debugFlag   = flag.Bool("debug", false, "Cause the repository data to be printed in verbose debug format.")
+	fFlag       = flag.Bool("f", false, "Force not to verify that each package has been checked out from the source control repository implied by its import path. This can be useful if the source is a local fork of the original.")
+	stdinFlag   = flag.Bool("stdin", false, "Read the list of newline separated Go packages from stdin.")
+	vFlag       = flag.Bool("v", false, "Verbose mode. Show all Go packages, not just ones with notable status.")
+	compactFlag = flag.Bool("c", false, "Compact output with inline notation.")
 )
 
 var wd = func() string {
@@ -46,11 +47,11 @@ Examples:
   go list -f '{{join .Deps "\n"}}' . | gostatus -stdin -v
 
 Legend:
-  ???? - Not under (recognized) version control
+  ? - Not under (recognized) version control
   b - Non-master branch checked out
   * - Uncommited changes in working dir
   + - Update available
-  - - Local revision is ahead of remote (need to push?)
+  - - Local revision is ahead of remote
   ! - No remote
   # - Remote path doesn't match import path
   $ - Stash exists
@@ -66,7 +67,7 @@ func main() {
 	default:
 		shouldShow = func(r *Repo) bool {
 			// Check for notable status.
-			return PorcelainPresenter(r)[:4] != "    "
+			return CompactPresenter(r)[:4] != "    "
 		}
 	case *vFlag:
 		shouldShow = func(*Repo) bool { return true }
@@ -76,6 +77,8 @@ func main() {
 	switch {
 	case *debugFlag:
 		presenter = DebugPresenter
+	case *compactFlag:
+		presenter = CompactPresenter
 	default:
 		presenter = PorcelainPresenter
 	}


### PR DESCRIPTION
Move current compact output behind `-c` flag.

~~Rename `-v` flag to `-all`.~~

Resolves #29.

An example of new default output:

```
$ gostatus all
github.com/kr/text/...
    ! No remote
github.com/mvdan/interfacer/...
    + Update available
golang.org/x/crypto/...
    + Update available
google.golang.org/cloud/...
    + Update available
google.golang.org/grpc/...
    + Update available
github.com/daviddengcn/go-colortext/...
    + Update available
github.com/go-gl/mathgl/...
    + Update available
github.com/golang/gddo/...
    b Non-master branch checked out
    # Remote path doesn't match import path
    $ Stash exists
github.com/gopherjs/cmd-go-js/...
    * Uncommited changes in working dir
    ! No remote
github.com/google/go-github/...
    + Update available
github.com/gopherjs/vendor/go/build
    ? Not under (recognized) version control
github.com/gophergala2016/cmd-go-js/...
    * Uncommited changes in working dir
github.com/gopherjs/gopherjs/...
    * Uncommited changes in working dir
    + Update available
github.com/shurcooL/gostatus/...
    b Non-master branch checked out
github.com/shurcooL/home/...
    * Uncommited changes in working dir
github.com/shurcooL/play/...
    * Uncommited changes in working dir
github.com/shurcooL/vcsstate/...
    * Uncommited changes in working dir
    - Local revision is ahead of remote
golang.org/x/mobile/...
    + Update available
golang.org/x/tools/...
    + Update available
golang.org/x/net/...
    + Update available
sourcegraph.com/sourcegraph/go-diff/...
    * Uncommited changes in working dir
vecty.io/vecty/...
    ! No remote
```

And for comparison, this is the current output (which in the future will require `-c` flag):

```
$ gostatus -c all
  !  github.com/kr/text/...
  +  github.com/mvdan/interfacer/...
  +  golang.org/x/crypto/...
  +  google.golang.org/cloud/...
  +  google.golang.org/grpc/...
  +  github.com/daviddengcn/go-colortext/...
b #$ github.com/golang/gddo/...
 *!  github.com/gopherjs/cmd-go-js/...
  +  github.com/go-gl/mathgl/...
  +  github.com/google/go-github/...
???? github.com/gopherjs/vendor/go/build
 *   github.com/gophergala2016/cmd-go-js/...
 *+  github.com/gopherjs/gopherjs/...
b    github.com/shurcooL/gostatus/...
 *   github.com/shurcooL/home/...
 *   github.com/shurcooL/play/...
 *-  github.com/shurcooL/vcsstate/...
  +  golang.org/x/net/...
  +  golang.org/x/mobile/...
  +  golang.org/x/tools/...
 *   sourcegraph.com/sourcegraph/go-diff/...
  !  vecty.io/vecty/...
```
