### PR TITLE
Remove .git extension when checking URL equality

### DIFF
--- a/status/url.go
+++ b/status/url.go
@@ -5,6 +5,7 @@ package status
 import (
 	"net/url"
 	"regexp"
+	"strings"
 )
 
 // EqualRepoURLs reports whether two URLs are equal, ignoring scheme and userinfo.
@@ -21,7 +22,7 @@ func EqualRepoURLs(rawurl1, rawurl2 string) bool {
 	}
 	u.Scheme, v.Scheme = "", "" // Ignore scheme.
 	u.User, v.User = nil, nil   // Ignore username and password information.
-	return u.String() == v.String()
+	return trimGitExt(u.String()) == trimGitExt(v.String())
 }
 
 // scpSyntaxRe matches the SCP-like addresses used by Git to access repositories by SSH.
@@ -41,4 +42,8 @@ func parseURL(rawurl string) (*url.URL, error) {
 	}
 
 	return url.Parse(rawurl)
+}
+
+func trimGitExt(url string) string {
+	return strings.TrimRight(url, ".git")
 }

--- a/status/url_test.go
+++ b/status/url_test.go
@@ -18,12 +18,22 @@ func TestEqualRepoURLs(t *testing.T) {
 		},
 		{
 			rawurl1: "https://github.com/user/repo",
+			rawurl2: "https://github.com/user/repo.git",
+			want:    true,
+		},
+		{
+			rawurl1: "https://github.com/user/repo",
 			rawurl2: "https://github.com/user/wrongrepo",
 			want:    false,
 		},
 		{
 			rawurl1: "https://github.com/user/repo",
 			rawurl2: "git@github.com:user/repo",
+			want:    true,
+		},
+		{
+			rawurl1: "https://github.com/user/repo",
+			rawurl2: "git@github.com:user/repo.git",
 			want:    true,
 		},
 	}
@@ -45,8 +55,16 @@ func TestParseURL(t *testing.T) {
 			want: "ssh://git@github.com/user/repo",
 		},
 		{
+			in:   "git@github.com:user/repo.git",
+			want: "ssh://git@github.com/user/repo.git",
+		},
+		{
 			in:   "https://github.com/user/repo",
 			want: "https://github.com/user/repo",
+		},
+		{
+			in:   "https://github.com/user/repo.git",
+			want: "https://github.com/user/repo.git",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
As I saw it there was two ways to go about this:
1. Remove git extension only when comparing URLs for equality (this PR)
2. Remove git extension when parsing the URL

Options 2 does not feel like correct behavior since it changes the real URL.

Fixes #37.

PS. Added tests for both cases.
